### PR TITLE
Fix bulk-load.js loading items as "null"

### DIFF
--- a/config/bulk-load.js
+++ b/config/bulk-load.js
@@ -1,5 +1,13 @@
 var rg = require("require-glob");
+const path = require('path');
+
 module.exports = function (folder) {
-  var items = rg.sync(__dirname + "/" + folder + "/*.js", {keygen: function (options, file) { return file.path.match(/\/([^\/.]+)\./)[1]; }});
+	
+  var items = rg.sync(__dirname + "/" + folder + "/*.js", {keygen: function (options, file)      
+  { 
+      //console.log("Loading item: " + file.path.replace(file.base + path.sep, '').replace(/.\w*$/, ''));
+      return file.path.replace(file.base + path.sep, '')
+      .replace(/.\w*$/, ''); }});
+	
   return items;
 }

--- a/index.js
+++ b/index.js
@@ -1,7 +1,8 @@
 require("coffee-script/register");
 require('app-module-path').addPath(__dirname);
 var log = require("logger");
-var respawn = require("respawn");
+//var respawn = require("respawn");
+var spawn = require("child_process").spawn;
 var db = require("database").db;
 var netconfig = require("config/netconfig");
 var path = require("path");
@@ -17,11 +18,14 @@ db.onConnect(1, function (err, connection) {
     var apps = ["botmanager", "frontend", "gameserver", "lobby"];
     
     apps.forEach(function(appName) {
-        var app = respawn(['node', path.join(__dirname, './' + appName + "/index.js")], {
+        /* var app = respawn(['node', ' ' + appName + "/index.js"], {
             kill: 1000,
             stdout: process.stdout,
             stderr: process.stderr
         });
-        app.start();
+        console.log("Starting " + appName + " with respawn " + app.pid);
+        app.start(); */
+        var app = spawn('node', [appName + "/index.js"]);
+        app.stdout.pipe(process.stdout);
     });
 });

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
 require("coffee-script/register");
 require('app-module-path').addPath(__dirname);
 var log = require("logger");
-//var respawn = require("respawn");
-var spawn = require("child_process").spawn;
+var respawn = require("respawn");
 var db = require("database").db;
 var netconfig = require("config/netconfig");
 var path = require("path");
@@ -18,14 +17,11 @@ db.onConnect(1, function (err, connection) {
     var apps = ["botmanager", "frontend", "gameserver", "lobby"];
     
     apps.forEach(function(appName) {
-        /* var app = respawn(['node', ' ' + appName + "/index.js"], {
+        var app = respawn(['node', path.join(__dirname, './' + appName + "/index.js")], {
             kill: 1000,
             stdout: process.stdout,
             stderr: process.stderr
         });
-        console.log("Starting " + appName + " with respawn " + app.pid);
-        app.start(); */
-        var app = spawn('node', [appName + "/index.js"]);
-        app.stdout.pipe(process.stdout);
+        app.start();
     });
 });


### PR DESCRIPTION
<sub>Hey, it's me again, the same guy who made stupid issues and bothered you on facebook quite a while ago. After 4 years, I have returned with much more coding (and life) knowledge, ready to get this project into a more usable state</sub>

Running any Tower Storm's node app that uses the `bulk-load.js` file (ex. `botmanager/index.js`) causes it to crash, due to `file.path.match(/\/([^\/.]+)\./)` returning null.

This pull request fixes that by replacing the `file.path.match` function with `file.replace`, and changing regex to target the file extension.

Regex should only target the characters after the last dot, to prevent files like `foo.bar.js` being read as `foo`.