### PR TITLE
Fix respawn function not working by switching it to node's spawn

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 require("coffee-script/register");
 require('app-module-path').addPath(__dirname);
 var log = require("logger");
-var respawn = require("respawn");
+var spawn = require("child_process").spawn;
 var db = require("database").db;
 var netconfig = require("config/netconfig");
 var path = require("path");
@@ -17,11 +17,7 @@ db.onConnect(1, function (err, connection) {
     var apps = ["botmanager", "frontend", "gameserver", "lobby"];
     
     apps.forEach(function(appName) {
-        var app = respawn(['node', path.join(__dirname, './' + appName + "/index.js")], {
-            kill: 1000,
-            stdout: process.stdout,
-            stderr: process.stderr
-        });
-        app.start();
+        var app = spawn('node', [appName + "/index.js"]);
+        app.stdout.pipe(process.stdout);
     });
 });


### PR DESCRIPTION
Respawn function is broken, doesn't actually run any of the node apps, and doesn't show any error.

I don't know the exact cause of this. I believe this may either be caused by old "Respawn" package being incompatible with newer npm versions, or Windows incompatibility with some of the functions that were coded directly for Linux-based systems.

Either way, replacing this function with node's internal Spawn function gets rids of this issue.

(Todo: this issue should be looked in further to reimplement the respawning of crashed processes. For now this fix is enough, as having an app that doesn't restart is better than one that doesn't run in the first place)